### PR TITLE
allow LightXML 0.9

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -9,7 +9,7 @@ LightXML = "9c8b4983-aa76-5018-a973-4c85ecc9e179"
 
 [compat]
 HTTP = "0.8"
-LightXML = "0.8"
+LightXML = "0.8, 0.9"
 julia = "1.3"
 
 [extras]


### PR DESCRIPTION
Currently Polyline can't be installed in v1.0.0 when LightOSM is installed as LightOSM expects version 0.9 of LightXML